### PR TITLE
fix(index.d.ts): Fix type checking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ export type SectionItem<ItemType> = {
 // Original section list component props
 type SectionGridAllowedProps<ItemType = any> = Omit<SectionListProps<ItemType>,
   //  This prop doesn't affect the SectionGrid, which only scrolls vertically.
-  | "horizontal"
+  | "horizontal" | "sections"
 >
 
 export interface SectionGridProps<ItemType = any>


### PR DESCRIPTION
# Description

When using typescript with https://github.com/saleel/react-native-super-grid I got this error when generating my types:

```
Interface 'SectionGridProps<ItemType>' incorrectly extends interface 'Pick<SectionListProps<ItemType>, "style" | "data" | "pointerEvents" | "onTouchCancel" | "onTouchEnd" | "onTouchEndCapture" | "onTouchMove" | "onTouchStart" | "onScroll" | ... 126 more ... | "sections">'.
  Types of property 'sections' are incompatible.
    Type 'SectionItem<ItemType>[]' is not assignable to type 'readonly SectionListData<ItemType>[]'.
      Type 'SectionItem<ItemType>' is not assignable to type 'SectionListData<ItemType>'.
        Types of property 'renderItem' are incompatible.
          Type 'GridRenderItem<ItemType> | undefined' is not assignable to type 'SectionListRenderItem<ItemType> | undefined'.
            Type 'GridRenderItem<ItemType>' is not assignable to type 'SectionListRenderItem<ItemType>'.
              Types of parameters 'info' and 'info' are incompatible.
                Type 'SectionListRenderItemInfo<ItemType>' is not assignable to type 'GridRenderItemInfo<ItemType>'.
                  Property 'rowIndex' is missing in type 'SectionListRenderItemInfo<ItemType>' but required in type '{ rowIndex: number; }'.

91 export interface SectionGridProps<ItemType = any>
```

# Resolution

Then I decided to omit the `sections` field.
I do not know if it is the best way to do it 